### PR TITLE
init.bat と update_all_plugins.bat をリリースアセットに追加する (#3)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,3 +56,6 @@ jobs:
           prerelease: ${{ github.event_name }} == "workflow_dispatch"
           preserve_order: # optional
           generate_release_notes: ${{ github.event_name == 'tag' && true || false }}
+          files: |
+            init.bat
+            update_all_plugins.bat

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,11 +6,7 @@ on:
     tags:
       - '[1-9][0-9]+.[0-9]+.[0-9]+(-((RC)|(GA)).[1-9][0-9]*)?'
 
-# 各種パラメータを環境変数として設定
 env:
-  PYTHON_VER: '3.12.10'
-  WIN_ARC: 'x64'
-  SCRIPT_NAME: AiArtImpostor-BepInExMods
   DRAFT_TAG_NAME: ''
 
 permissions:
@@ -19,33 +15,17 @@ permissions:
 jobs:
   release:
     name: Release
-    # 最新のWindows環境を利用するよう指定します。
     runs-on: windows-latest
 
     steps:
       - name: '### チェックアウト ###'
         uses: actions/checkout@v6.0.2
-        
+
       - name: '### 環境変数設定 ###'
         id: set_evn
-        run: | 
-          "DRAFT_TAG_NAME=v$(date +'%Y.%m.%d.%H%M%S')" >> $env:GITHUB_ENV
-       
-      - name: '### 環境変数チェック ###'
-        id: check_env
         run: |
-          echo "github.ref_name: ${{ github.ref_name }}"
-          Get-ChildItem env:
+          "DRAFT_TAG_NAME=v$(date +'%Y.%m.%d.%H%M%S')" >> $env:GITHUB_ENV
 
-      - name: '### init.batをアーティファクト(.zip)としてアップロード ###'
-        id: artifact-upload-step
-        uses: actions/upload-artifact@v7.0.0
-        with:
-          name: SetupScript
-          path: init.bat
-          if-no-files-found: error
-          compression-level: 9
-          
       - name: '### リリース ###'
         uses: softprops/action-gh-release@v2.5.0
         env:
@@ -54,7 +34,6 @@ jobs:
           tag_name: ${{ github.ref_type == 'tag' && github.ref_name || env.DRAFT_TAG_NAME }}
           draft: ${{ github.event_name }} == "workflow_dispatch"
           prerelease: ${{ github.event_name }} == "workflow_dispatch"
-          preserve_order: # optional
           generate_release_notes: ${{ github.event_name == 'tag' && true || false }}
           files: |
             init.bat

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: '### チェックアウト ###'
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v4
 
       - name: '### 環境変数設定 ###'
         id: set_evn
         run: |
-          "DRAFT_TAG_NAME=v$(date +'%Y.%m.%d.%H%M%S')" >> $env:GITHUB_ENV
+          "DRAFT_TAG_NAME=v$(Get-Date -Format 'yyyy.MM.dd.HHmmss')" >> $env:GITHUB_ENV
 
       - name: '### リリース ###'
         uses: softprops/action-gh-release@v2.5.0
@@ -32,9 +32,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref_type == 'tag' && github.ref_name || env.DRAFT_TAG_NAME }}
-          draft: ${{ github.event_name }} == "workflow_dispatch"
-          prerelease: ${{ github.event_name }} == "workflow_dispatch"
-          generate_release_notes: ${{ github.event_name == 'tag' && true || false }}
+          draft: ${{ github.event_name == 'workflow_dispatch' }}
+          prerelease: ${{ github.event_name == 'workflow_dispatch' }}
+          generate_release_notes: ${{ github.ref_type == 'tag' }}
           files: |
             init.bat
             update_all_plugins.bat

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,10 @@ jobs:
         run: |
           "DRAFT_TAG_NAME=v$(Get-Date -Format 'yyyy.MM.dd.HHmmss')" >> $env:GITHUB_ENV
 
+      - name: '### スクリプトをzip化 ###'
+        run: |
+          Compress-Archive -Path init.bat, update_all_plugins.bat -DestinationPath SetupScripts.zip
+
       - name: '### リリース ###'
         uses: softprops/action-gh-release@v2.5.0
         env:
@@ -35,6 +39,4 @@ jobs:
           draft: ${{ github.event_name == 'workflow_dispatch' }}
           prerelease: ${{ github.event_name == 'workflow_dispatch' }}
           generate_release_notes: ${{ github.ref_type == 'tag' }}
-          files: |
-            init.bat
-            update_all_plugins.bat
+          files: SetupScripts.zip


### PR DESCRIPTION
  ## 概要

  GitHub Release ページから `init.bat` と `update_all_plugins.bat` を直接ダウンロードできるようにします。

  ## 変更内容

  - `.github/workflows/main.yml`: `softprops/action-gh-release` の `files` パラメータに両ファイルを追加

  Closes #3